### PR TITLE
Improve README and sample requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,70 @@
 # SampleDDD
 
-This repository contains a minimal Domain-Driven Design (DDD) style web API using ASP.NET Core 8.
+A minimal Domain-Driven Design (DDD) style API using ASP.NET Core 8.
 
-## Projects
+## Solution structure
 
-- **Domain**: Core business entities and repository interfaces.
-- **Application**: Application services containing business logic.
-- **Infrastructure**: Infrastructure implementations (in-memory repository).
-- **WebApi**: ASP.NET Core minimal API exposing endpoints.
+The solution is split into four projects:
 
-## Run
+- **Domain** – contains the `TodoItem` entity and `ITodoRepository` interface.
+- **Application** – application services such as `TodoService` which orchestrate the domain.
+- **Infrastructure** – infrastructure implementations. An in-memory repository (`InMemoryTodoRepository`) is provided for demos.
+- **WebApi** – ASP.NET Core minimal API exposing the HTTP endpoints.
 
-```bash
-cd src/WebApi
-dotnet run
+```
+SampleDDD.sln
+ ├─ Domain
+ ├─ Application
+ ├─ Infrastructure
+ └─ WebApi
 ```
 
-You can then access Swagger UI at `https://localhost:5001/swagger` to test the API.
+## Prerequisites
+
+- .NET SDK 8.0
+
+Verify the SDK is installed:
+
+```bash
+dotnet --version
+```
+
+## Build and run
+
+To build the entire solution from the command line:
+
+```bash
+dotnet build SampleDDD.sln
+```
+
+To run the API:
+
+```bash
+dotnet run --project src/WebApi/SampleDDD.WebApi.csproj
+```
+
+You can also open `SampleDDD.sln` in Visual Studio and run the WebApi project from there.
+
+Swagger is enabled in development. Once running, navigate to `http://localhost:5176/swagger` (or the URL printed by `dotnet run`) to explore the API interactively.
+
+## API endpoints
+
+| Method | Endpoint           | Description                   |
+|-------|-------------------|-------------------------------|
+| `POST` | `/todos?title=todo` | Add a new todo item. Returns `200 OK`.
+| `GET`  | `/todos`           | Returns all todo items as JSON array.
+| `GET`  | `/todos/{id}`      | Returns the todo with the specified `id` or `404` if not found.
+
+Example request to create and retrieve items using `curl`:
+
+```bash
+# Add a todo
+curl -X POST "http://localhost:5176/todos?title=Buy%20milk"
+
+# List todos
+curl http://localhost:5176/todos
+
+# Get one by id
+curl http://localhost:5176/todos/<id>
+```
 

--- a/src/WebApi/SampleDDD.WebApi.http
+++ b/src/WebApi/SampleDDD.WebApi.http
@@ -1,6 +1,11 @@
 @SampleDDD.WebApi_HostAddress = http://localhost:5176
 
-GET {{SampleDDD.WebApi_HostAddress}}/weatherforecast/
+### Get all todos
+GET {{SampleDDD.WebApi_HostAddress}}/todos
 Accept: application/json
 
-###
+### Create a new todo
+POST {{SampleDDD.WebApi_HostAddress}}/todos?title=Buy%20milk
+
+### Get todo by id
+GET {{SampleDDD.WebApi_HostAddress}}/todos/{id}


### PR DESCRIPTION
## Summary
- clean up leftover `weatherforecast` snippet in sample request file
- explain solution structure, prereqs and build instructions
- document todo API endpoints and Swagger usage

## Testing
- `dotnet build SampleDDD.sln`
- `dotnet run --project src/WebApi/SampleDDD.WebApi.csproj --urls http://localhost:5140`

------
https://chatgpt.com/codex/tasks/task_e_6841435066f88322af34f16011d0e3bd