### PR TITLE
Add todo sample requests

### DIFF
--- a/src/WebApi/SampleDDD.WebApi.http
+++ b/src/WebApi/SampleDDD.WebApi.http
@@ -1,6 +1,19 @@
 @SampleDDD.WebApi_HostAddress = http://localhost:5176
 
-GET {{SampleDDD.WebApi_HostAddress}}/weatherforecast/
+### Create a new todo item
+POST {{SampleDDD.WebApi_HostAddress}}/todos
+Content-Type: application/json
+
+{
+    "title": "Sample todo"
+}
+
+### Retrieve all todo items
+GET {{SampleDDD.WebApi_HostAddress}}/todos
+Accept: application/json
+
+### Retrieve a todo item by id
+GET {{SampleDDD.WebApi_HostAddress}}/todos/{id}
 Accept: application/json
 
 ###


### PR DESCRIPTION
## Summary
- replace weatherforecast sample request with todo API examples

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684143557b088322b091051bc95b3b31